### PR TITLE
Fix function arguments/missing header for libc functions

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -31,6 +31,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include "edit.h"
 #include "util/rnd.h"
 #include <string.h>
+#include <sys/stat.h>
 #include "snd/cydwave.h"
 #include "snd/freqs.h"
 #include "mymsg.h"
@@ -181,7 +182,7 @@ void do_autosave(Uint32* timeout)
 			{
 				debug("No autosaves directory found, attempt to create it...");
 				
-				int check = mkdir(dir_name);
+				int check = mkdir(dir_name, S_IRWXU);
 				
 				if(!check)
 				{

--- a/src/mused.c
+++ b/src/mused.c
@@ -39,6 +39,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include "diskop.h"
 #include <stdarg.h>
 #include <string.h>
+#include <unistd.h>
 
 extern Mused mused;
 extern Menu editormenu[];


### PR DESCRIPTION
All the required information is in the individual commit messages.