### PR TITLE
Midi Fix

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -69,6 +69,7 @@ static const struct { int type; const char *name; void *param; Uint64 mask; } co
 #ifdef MIDI
 	{ C_INT, "midi_device", &mused.midi_device },
 	{ C_INT, "midi_channel", &mused.midi_channel },
+	{ C_INT, "midi_octave", &mused.midi_octave },
 #endif
 	{ C_BOOL, "lock_pattern_length", &mused.flags, LOCK_SEQUENCE_STEP_AND_PATTERN_LENGTH },
 	{ C_BOOL, "edit_sequence_digits", &mused.flags, EDIT_SEQUENCE_DIGITS },

--- a/src/event.c
+++ b/src/event.c
@@ -182,7 +182,11 @@ void do_autosave(Uint32* timeout)
 			{
 				debug("No autosaves directory found, attempt to create it...");
 				
-				int check = mkdir(dir_name, S_IRWXU);
+				#ifdef WIN32
+					int check = mkdir(dir_name);
+				#else
+					int check = mkdir(dir_name, S_IRWXU);
+				#endif
 				
 				if(!check)
 				{

--- a/src/event.c
+++ b/src/event.c
@@ -5811,7 +5811,7 @@ void note_event(SDL_Event *e)
 	{
 		case MSG_NOTEON:
 		{
-			Uint32 note = e->user.code + 12 * 5; //to account for negative octaves
+			Uint32 note = e->user.code + 12 * (mused.midi_octave + 5); //to account for negative octaves
 			
 			play_note(note);
 			
@@ -5824,7 +5824,7 @@ void note_event(SDL_Event *e)
 
 		case MSG_NOTEOFF:
 		{
-			Uint32 note = e->user.code + 12 * 5; //to account for negative octaves
+			Uint32 note = e->user.code + 12 * (mused.midi_octave + 5); //to account for negative octaves
 			
 			stop_note(note);
 		}

--- a/src/midi.h
+++ b/src/midi.h
@@ -39,6 +39,7 @@ void midi_event(SDL_Event *e);
 void midi_init();
 void midi_deinit();
 void midi_set_channel(void *chn, void *unused1, void *unused2);
+void midi_set_octave(void *octave, void *unused1, void *unused2);
 
 #endif
 

--- a/src/mused.h
+++ b/src/mused.h
@@ -303,6 +303,7 @@ typedef struct
 	Uint16 midi_rate;
 	Uint32 midi_last_clock;
 	Uint8 tick_ctr;
+	int midi_octave;
 #endif
 
 	WgSettings wgset;


### PR DESCRIPTION
A) Some midi keyboards register a "note off" event as a "note on" with zero velocity. The midi callback function now accounts for this.

B) Different MIDI keyboards have different standards for numbering notes. I added an "octave" dropdown with the options -3,-2,-1,0,+1,+2,+3. It saves this setting to the config file.

C) The previous pull request changed a line in event.c that calls mkdir, which seems to work differently on Windows vs other platforms. I added a preprocessor check.